### PR TITLE
Cocoapods Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 # Xcode - User files
 *xcuserdata/
 
-# Carthage
-Core\ ML\ Vision\ Custom/Carthage/
+# Cocoapods
+Core\ ML\ Vision\ Custom/Pods

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,6 @@
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Core ML Vision Custom/Carthage
+  - Core ML Vision Custom/Pods
   - Core ML Vision Custom/Core ML Vision Custom/Supporting Files
 
 disabled_rules:

--- a/Core ML Vision Custom/Cartfile
+++ b/Core ML Vision Custom/Cartfile
@@ -1,1 +1,0 @@
-github "watson-developer-cloud/swift-sdk" ~> 1.2

--- a/Core ML Vision Custom/Cartfile.resolved
+++ b/Core ML Vision Custom/Cartfile.resolved
@@ -1,3 +1,0 @@
-github "daltoniam/Starscream" "3.0.5"
-github "watson-developer-cloud/restkit" "2.0.0"
-github "watson-developer-cloud/swift-sdk" "1.2.0"

--- a/Core ML Vision Custom/Core ML Vision Custom.xcodeproj/project.pbxproj
+++ b/Core ML Vision Custom/Core ML Vision Custom.xcodeproj/project.pbxproj
@@ -14,30 +14,14 @@
 		2308B8F520F66151009C7CBD /* UIViewController+PulleyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308B8F020F66151009C7CBD /* UIViewController+PulleyViewController.swift */; };
 		2308B8F620F66151009C7CBD /* PulleyPassthroughScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308B8F120F66151009C7CBD /* PulleyPassthroughScrollView.swift */; };
 		2308B8F720F66151009C7CBD /* UIView+constrainToParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308B8F220F66151009C7CBD /* UIView+constrainToParent.swift */; };
+		2757C0506D2CFDAD1CD46E9A /* Pods_Core_ML_Vision_Custom.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D584BD5CB71B1640556C664A /* Pods_Core_ML_Vision_Custom.framework */; };
 		2D6D8B1F1FDF53FD00C3A77B /* ImageClassificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6D8B1E1FDF53FD00C3A77B /* ImageClassificationViewController.swift */; };
 		2D7B571B20509EE6009ACA53 /* SwiftSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7B571A20509EE6009ACA53 /* SwiftSpinner.swift */; };
 		2DBDD2741FCF7F88004A6DC1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBDD2731FCF7F88004A6DC1 /* AppDelegate.swift */; };
 		2DBDD27E1FCF7F88004A6DC1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DBDD27D1FCF7F88004A6DC1 /* Assets.xcassets */; };
 		2DBDD2811FCF7F88004A6DC1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DBDD27F1FCF7F88004A6DC1 /* LaunchScreen.storyboard */; };
 		2DC5F1371FD5F3200063B2D5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DC5F1361FD5F3200063B2D5 /* Main.storyboard */; };
-		92FB01322147212C00F7004B /* RestKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 92FB01302147211600F7004B /* RestKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		92FB01352147232E00F7004B /* VisualRecognitionV3.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 92FB01332147232800F7004B /* VisualRecognitionV3.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		71C8518220655A9000D855B2 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				92FB01352147232E00F7004B /* VisualRecognitionV3.framework in Embed Frameworks */,
-				92FB01322147212C00F7004B /* RestKit.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		2308B8E920F6613A009C7CBD /* ResultsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultsTableViewController.swift; sourceTree = "<group>"; };
@@ -55,8 +39,9 @@
 		2DBDD2801FCF7F88004A6DC1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		2DBDD2821FCF7F88004A6DC1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2DC5F1361FD5F3200063B2D5 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		92FB01302147211600F7004B /* RestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RestKit.framework; path = Carthage/Build/iOS/RestKit.framework; sourceTree = SOURCE_ROOT; };
-		92FB01332147232800F7004B /* VisualRecognitionV3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VisualRecognitionV3.framework; path = Carthage/Build/iOS/VisualRecognitionV3.framework; sourceTree = SOURCE_ROOT; };
+		7C703C11EF7C531FE940DDED /* Pods-Core ML Vision Custom.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core ML Vision Custom.release.xcconfig"; path = "Pods/Target Support Files/Pods-Core ML Vision Custom/Pods-Core ML Vision Custom.release.xcconfig"; sourceTree = "<group>"; };
+		A23164D1529249DEA24E0288 /* Pods-Core ML Vision Custom.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core ML Vision Custom.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Core ML Vision Custom/Pods-Core ML Vision Custom.debug.xcconfig"; sourceTree = "<group>"; };
+		D584BD5CB71B1640556C664A /* Pods_Core_ML_Vision_Custom.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Core_ML_Vision_Custom.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2757C0506D2CFDAD1CD46E9A /* Pods_Core_ML_Vision_Custom.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,8 +81,9 @@
 			isa = PBXGroup;
 			children = (
 				2DBDD2721FCF7F88004A6DC1 /* Core ML Vision Custom */,
-				92FB012F2147210100F7004B /* Frameworks */,
 				2DBDD2711FCF7F88004A6DC1 /* Products */,
+				6F1810CDBF82E24117984E67 /* Pods */,
+				365D29D65A1AEF0FCB4E6973 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,13 +111,21 @@
 			path = "Core ML Vision Custom";
 			sourceTree = "<group>";
 		};
-		92FB012F2147210100F7004B /* Frameworks */ = {
+		365D29D65A1AEF0FCB4E6973 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				92FB01332147232800F7004B /* VisualRecognitionV3.framework */,
-				92FB01302147211600F7004B /* RestKit.framework */,
+				D584BD5CB71B1640556C664A /* Pods_Core_ML_Vision_Custom.framework */,
 			);
-			path = Frameworks;
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6F1810CDBF82E24117984E67 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A23164D1529249DEA24E0288 /* Pods-Core ML Vision Custom.debug.xcconfig */,
+				7C703C11EF7C531FE940DDED /* Pods-Core ML Vision Custom.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -140,10 +135,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DBDD2851FCF7F88004A6DC1 /* Build configuration list for PBXNativeTarget "Core ML Vision Custom" */;
 			buildPhases = (
+				3A56CEEE051D0031AAD8021D /* [CP] Check Pods Manifest.lock */,
 				2DBDD26C1FCF7F88004A6DC1 /* Sources */,
 				2DBDD26D1FCF7F88004A6DC1 /* Frameworks */,
 				2DBDD26E1FCF7F88004A6DC1 /* Resources */,
-				71C8518220655A9000D855B2 /* Embed Frameworks */,
+				2502DF4C8F31E0D404A440DC /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -167,7 +163,7 @@
 					2DBDD26F1FCF7F88004A6DC1 = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = 1010;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -201,6 +197,55 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2502DF4C8F31E0D404A440DC /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Core ML Vision Custom/Pods-Core ML Vision Custom-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/IBMWatsonRestKit/RestKit.framework",
+				"${BUILT_PRODUCTS_DIR}/IBMWatsonVisualRecognitionV3/VisualRecognition.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RestKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VisualRecognition.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Core ML Vision Custom/Pods-Core ML Vision Custom-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3A56CEEE051D0031AAD8021D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Core ML Vision Custom-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2DBDD26C1FCF7F88004A6DC1 /* Sources */ = {
@@ -347,18 +392,17 @@
 		};
 		2DBDD2861FCF7F88004A6DC1 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A23164D1529249DEA24E0288 /* Pods-Core ML Vision Custom.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Core ML Vision Custom/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ibm.watson.developer-cloud.Core-ML-Vision-Custom";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -366,18 +410,17 @@
 		};
 		2DBDD2871FCF7F88004A6DC1 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7C703C11EF7C531FE940DDED /* Pods-Core ML Vision Custom.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Core ML Vision Custom/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ibm.watson.developer-cloud.Core-ML-Vision-Custom";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Core ML Vision Custom/Core ML Vision Custom/ImageClassificationViewController.swift
+++ b/Core ML Vision Custom/Core ML Vision Custom/ImageClassificationViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 import AVFoundation
-import VisualRecognitionV3
+import VisualRecognition
 
 struct VisualRecognitionConstants {
     static let apikey = ""     // The IAM apikey
@@ -189,7 +189,7 @@ class ImageClassificationViewController: UIViewController {
         push(results: [], position: .closed)
     }
 
-    func push(results: [VisualRecognitionV3.ClassifierResult], position: PulleyPosition = .partiallyRevealed) {
+    func push(results: [ClassifierResult], position: PulleyPosition = .partiallyRevealed) {
         guard let drawer = pulleyViewController?.drawerContentViewController as? ResultsTableViewController else {
             return
         }

--- a/Core ML Vision Custom/Core ML Vision Custom/ResultsTableViewController.swift
+++ b/Core ML Vision Custom/Core ML Vision Custom/ResultsTableViewController.swift
@@ -15,7 +15,7 @@
  **/
 
 import UIKit
-import VisualRecognitionV3
+import VisualRecognition
 
 class ResultsTableViewController: UIViewController {
 
@@ -34,7 +34,7 @@ class ResultsTableViewController: UIViewController {
 
     // MARK: - Variable Declarations
 
-    var classifications = [VisualRecognitionV3.ClassifierResult]()
+    var classifications = [ClassifierResult]()
     var drawerBottomSafeArea: CGFloat = 0.0 {
         didSet {
             self.loadViewIfNeeded()

--- a/Core ML Vision Custom/Podfile
+++ b/Core ML Vision Custom/Podfile
@@ -1,0 +1,14 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '10.0'
+
+workspace '../QuickstartWorkspace'
+project 'Core ML Vision Custom.xcodeproj'
+
+target 'Core ML Vision Custom' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for Core ML Vision Custom
+  pod 'IBMWatsonVisualRecognitionV3', '~> 1.3.1'
+
+end

--- a/Core ML Vision Custom/Podfile.lock
+++ b/Core ML Vision Custom/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - IBMWatsonRestKit (2.0.0)
+  - IBMWatsonVisualRecognitionV3 (1.3.1):
+    - IBMWatsonRestKit (~> 2.0.0)
+
+DEPENDENCIES:
+  - IBMWatsonVisualRecognitionV3 (~> 1.3.1)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - IBMWatsonRestKit
+    - IBMWatsonVisualRecognitionV3
+
+SPEC CHECKSUMS:
+  IBMWatsonRestKit: 0a8d0f2f1cc757a0231729e9206e0b774cda0997
+  IBMWatsonVisualRecognitionV3: b64efa95c24dfeeb7f426e09aaa52866de65860a
+
+PODFILE CHECKSUM: 830a2e9a06b1930c99e2ecc4fef7cad907e031e4
+
+COCOAPODS: 1.5.3

--- a/QuickstartWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/QuickstartWorkspace.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Core ML Vision Custom/Core ML Vision Custom.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Core ML Vision Custom/Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/README-cn.md
+++ b/README-cn.md
@@ -39,15 +39,15 @@
 
 ### 训练模型
 1.  在 Watson Studio 中的 Visual Recognition 实例概述页面上，单击 Custom 框中的 **Create Model**。
-1.  如果尚未将任何项目与您创建的 Visual Recognition 实例关联，将会创建一个项目。请将项目命名为 `Custom Core ML`，然后单击 **Create**。 
+1.  如果尚未将任何项目与您创建的 Visual Recognition 实例关联，将会创建一个项目。请将项目命名为 `Custom Core ML`，然后单击 **Create**。
 
     **提示**：如果未定义存储，请单击 **refresh**。
 1.  将每个样本图像 .zip 文件从 `Training Images` 目录上传至页面右侧的数据窗格中。单击数据窗格中的 **Browse** 按钮，将 `hdmi_male.zip` 文件添加到模型中。同时将 `usb_male.zip`、`thunderbolt_male.zip` 和 `vga_male.zip` 文件添加到模型中。
 1.  上传这些文件后，从每个文件旁的菜单中选择 **Add to model**，然后单击 **Train Model**。
 
 ### 复制模型 ID 和 API 密钥
-1.  在 Watson Studio 中的自定义模型概述页面上，单击 Visual Recognition 实例名称（位于 Associated Service 旁）。 
-1.  向下滚动以查找刚才创建的 **Custom Core ML** 分类器。 
+1.  在 Watson Studio 中的自定义模型概述页面上，单击 Visual Recognition 实例名称（位于 Associated Service 旁）。
+1.  向下滚动以查找刚才创建的 **Custom Core ML** 分类器。
 1.  复制分类器的 **Model ID**。
 1.  在 Watson Studio 中的 Visual Recognition 实例概述页面上，单击 **Credentials** 选项卡，然后单击 **View credentials**。复制服务的 `api_key`。
 
@@ -57,14 +57,14 @@
 1.  复制 **api_key**，并将其粘贴到 [ImageClassificationViewController](../master/Core%20ML%20Vision%20Custom/Core%20ML%20Vision%20Custom/ImageClassificationViewController.swift)文件的 **apiKey** 属性中。
 
 ### 下载 Watson Swift SDK
-使用 Carthage 依赖关系管理器来下载和构建 Watson Swift SDK。
+使用 Cocoapods 依赖关系管理器来下载和构建 Watson Swift SDK。
 
-1.  安装 [Carthage](https://github.com/Carthage/Carthage#installing-carthage)。
+1.  安装 [Cocoapods](https://cocoapods.org/)。
 1.  打开终端窗口，浏览至 `Core ML Vision Custom` 目录。
 1.  运行以下命令以下载和构建 Watson Swift SDK：
 
     ```bash
-    carthage bootstrap --platform iOS
+    pod install
     ```
 
 **提示：** 定期下载 SDK 更新，以便与此项目的任何更新保持同步
@@ -92,7 +92,7 @@
 - [Apple 机器学习](https://developer.apple.com/machine-learning/)
 - [Core ML 文档](https://developer.apple.com/documentation/coreml)
 - [Watson Swift SDK](https://github.com/watson-developer-cloud/swift-sdk)
-- [IBM Cloud](https://bluemix.net)
+- [IBM Cloud](https://cloud.ibm.com)
 
 [vizreq_with_discovery]: https://github.com/watson-developer-cloud/visual-recognition-with-discovery-coreml/
 [xcode_download]: https://developer.apple.com/xcode/downloads/

--- a/README-ja.md
+++ b/README-ja.md
@@ -72,14 +72,14 @@ Watson Swift SDK を使用することで、基礎となる Core ML フレーム
 
 ### Watson Swift SDK をダウンロードする
 
-Carthage 依存管理マネージャーを使用して、Watson Swift SDK をダウンロードしてビルドします。
+Cocoapods 依存管理マネージャーを使用して、Watson Swift SDK をダウンロードしてビルドします。
 
-1.  [Carthage](https://github.com/Carthage/Carthage#installing-carthage) をインストール。
+1.  [Cocoapods](https://cocoapods.org/) をインストール。
 2.  ターミナルを開いて、`Core ML Vision Custom` ディレクトリに移動。
 3.  以下のコマンドを実行して、Watson Swift SDK をダウンロードし、ビルドする:
 
     ```bash
-    carthage bootstrap --platform iOS
+    pod install
     ```
 
     **Tip:** SDK のアップデートを定期的にダウンロードして、このプロジェクトのアップデートと同期してください。
@@ -107,7 +107,7 @@ Carthage 依存管理マネージャーを使用して、Watson Swift SDK をダ
 - [Apple 機械学習](https://developer.apple.com/machine-learning/)
 - [Core ML ドキュメント](https://developer.apple.com/documentation/coreml)
 - [Watson Swift SDK](https://github.com/watson-developer-cloud/swift-sdk)
-- [IBM Cloud](https://bluemix.net)
+- [IBM Cloud](https://cloud.ibm.com)
 
 [vizreq_with_discovery]: https://github.com/watson-developer-cloud/visual-recognition-with-discovery-coreml/
 [xcode_download]: https://developer.apple.com/xcode/downloads/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The second part of this project builds from the first part and trains a Visual R
 1.  If a project is not yet associated with the Visual Recognition instance you created, a project is created. Name your project `Custom Core ML` and click **Create**.
 
     **Tip**: If no storage is defined, click **refresh**.
-1.  Upload each .zip file of sample images from the `Training Images` directory onto the data pane on the right side of the page.  Add the `hdmi_male.zip` file to your model by clicking the **Browse** button in the data pane. Also add the `usb_male.zip`, `thunderbolt_male.zip`, and `vga_male.zip` files to your model.
+1.  Navigate to the **Assets** tab and upload each .zip file of sample images from the `Training Images` directory onto the data pane on the right side of the page.  Add the `hdmi_male.zip` file to your model by clicking the **Browse** button in the data pane. Also add the `usb_male.zip`, `thunderbolt_male.zip`, and `vga_male.zip` files to your model.
 1.  After the files are uploaded, select **Add to model** from the menu next to each file, and then click **Train Model**.
 
 ### Copy your Model ID and API Key
@@ -59,17 +59,17 @@ The second part of this project builds from the first part and trains a Visual R
 1.  Copy either your **api_key** or **apikey** and paste it into either the **api_key** or **apikey** property in the  [ImageClassificationViewController](../master/Core%20ML%20Vision%20Custom/Core%20ML%20Vision%20Custom/ImageClassificationViewController.swift) file.
 
 ### Downloading the Watson Swift SDK
-Use the Carthage dependency manager to download and build the Watson Swift SDK.
+Use the Cocoapods dependency manager to download and build the Watson Swift SDK.  The Watson Swift SDK can also be installed via [Carthage](https://github.com/watson-developer-cloud/swift-sdk#carthage) and [Swift Package Manager](https://github.com/watson-developer-cloud/swift-sdk#swift-package-manager).
 
-1.  Install [Carthage](https://github.com/Carthage/Carthage#installing-carthage).
+1.  Install [Cocoapods](https://cocoapods.org/).
 1.  Open a terminal window and navigate to the `Core ML Vision Custom` directory.
 1.  Run the following command to download and build the Watson Swift SDK:
 
     ```bash
-    carthage bootstrap --platform iOS
+    pod install
     ```
 
-**Tip:** Regularly download updates of the SDK so you stay in sync with any updates to this project.  If you are using a different Swift version from the SDK, add the `--no-use-binaries` flag to the above command.
+**Tip:** Regularly download updates of the SDK so you stay in sync with any updates to this project.  If you have updated to a new version, you may need to run `pod repo update` before installing.
 
 ### Testing the custom model
 


### PR DESCRIPTION
These changes migrate the Custom Core ML model to use Cocoapods instead of Carthage.  This reduces project bloat, as only the Visual Recognition framework needs to be installed as opposed to the entire Watson SDK.  This also makes the project consistent with all other Watson starters and patterns on the Apple Console.