### PR TITLE
Fixing CoreML Vision Simple crash on iPad when opening action sheet.

### DIFF
--- a/Core ML Vision Simple/Core ML Vision Simple/ImageClassificationViewController.swift
+++ b/Core ML Vision Simple/Core ML Vision Simple/ImageClassificationViewController.swift
@@ -109,6 +109,12 @@ class ImageClassificationViewController: UIViewController {
         photoSourcePicker.addAction(takePhoto)
         photoSourcePicker.addAction(choosePhoto)
         photoSourcePicker.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        if let popoverController = photoSourcePicker.popoverPresentationController {
+            popoverController.sourceView = self.view
+            popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            popoverController.permittedArrowDirections = []
+        }
 
         present(photoSourcePicker, animated: true)
     }


### PR DESCRIPTION
Tapping the camera button in CoreML Vision Simple when running on an iPad would cause the app to crash because the action sheet had nothing to attach to. This adds a small block to check if the action sheet has an attach point and if it doesn't it adds one in the middle of the screen. 
